### PR TITLE
Add dept head checklist items for treasury/techops to magfest plugin

### DIFF
--- a/magfest/site_sections/magfest_dept_checklist.py
+++ b/magfest/site_sections/magfest_dept_checklist.py
@@ -1,0 +1,48 @@
+from magfest import *
+
+
+@all_renderable(c.PEOPLE)
+class Root:
+    def index(self, session, message=''):
+        raise HTTPRedirect('../dept_checklist/?message={}', message)
+
+    def treasury(self, session, submitted=None, csrf_token=None):
+        attendee = session.admin_attendee()
+        if submitted:
+            try:
+                [item] = [item for item in attendee.dept_checklist_items if item.slug == 'treasury']
+            except:
+                item = DeptChecklistItem(slug='treasury', attendee=attendee)
+            check_csrf(csrf_token)  # since this form doesn't use our normal utility methods, we need to do this manually
+            session.add(item)
+            raise HTTPRedirect('../dept_checklist/index?message={}', 'Thanks for completing the MPoints form!')
+
+        return {}
+
+    def allotments(self, session, submitted=None, csrf_token=None, **params):
+        attendee = session.admin_attendee()
+        conf = DeptChecklistConf.instances['allotments']
+        if submitted:
+            try:
+                [item] = [item for item in attendee.dept_checklist_items if item.slug == 'allotments']
+            except:
+                item = DeptChecklistItem(slug='allotments', attendee=attendee)
+            check_csrf(csrf_token)  # since this form doesn't use our normal utility methods, we need to do this manually
+            item.comments = render('magfest_dept_checklist/allotments.txt', params).decode('utf-8')
+            session.add(item)
+            raise HTTPRedirect('../dept_checklist/index?message={}', 'Treasury checklist data uploaded')
+
+        return {}
+
+    def tech_requirements(self, session, submitted=None, csrf_token=None):
+        attendee = session.admin_attendee()
+        if submitted:
+            try:
+                [item] = [item for item in attendee.dept_checklist_items if item.slug == 'tech_requirements']
+            except:
+                item = DeptChecklistItem(slug='tech_requirements', attendee=attendee)
+            check_csrf(csrf_token)  # since this form doesn't use our normal utility methods, we need to do this manually
+            session.add(item)
+            raise HTTPRedirect('../dept_checklist/index?message={}', 'Thanks for completing the tech requirements form!')
+
+        return {}

--- a/magfest/templates/example_base.html
+++ b/magfest/templates/example_base.html
@@ -1,9 +1,0 @@
-{% extends "preregistration/preregbase.html" %}
-{% block title %}Example{% endblock %}
-{% block backlink %}{% endblock %}
-{% block content %}
-    <div class="masthead"></div>
-    <div class="panel panel-default" style="padding-left:15px">
-        {% block body %}{% endblock %}
-    </div>
-{% endblock %}

--- a/magfest/templates/magfest_dept_checklist/allotments.html
+++ b/magfest/templates/magfest_dept_checklist/allotments.html
@@ -1,0 +1,191 @@
+{% extends "base-admin.html" %}
+{% block title %}Department Checklist - Treasury{% endblock %}
+{% block content %}
+
+<script>
+    var showOrHideForm = function () {
+        setVisible('#formcontent', $.field('needs').prop('checked') && !$.field('defer').prop('checked'));
+    };
+    var showOrHideCash = function () {
+        setVisible('#cash', $.field('needs_cash').prop('checked'));
+    };
+    var showOrHideMPoints = function () {
+        setVisible('#mpoints', $.field('needs_mpoints').prop('checked'));
+    };
+</script>
+<style type="text/css">
+    table.padded td, table.padded th {
+        padding: 5px 10px 5px 10px;
+    }
+    table.previous th, table.previous td.centered {
+        text-align: center;
+    }
+</style>
+
+<h2>Treasury Information</h2>
+
+<form method="post" action="allotments">
+{% csrf_token %}
+<input type="checkbox" name="needs" value="yes" onClick="showOrHideForm()" /> Check this box if your department needs cash and/or MPoints, otherwise just submit this form to let us know you DON'T need any <br/>
+<input type="checkbox" name="defer" value="yes" onClick="showOrHideForm()" /> Check this box if someone else is filling out this form for your department (seriously, don't everyone just check this!) <br/>
+<div id="formcontent" style="display:none">
+    <br/>
+    Please provide the name of the department head who will be making cash decisions: <br/>
+    <input type="text" name="dept_head_name" />
+
+    <br/> <br/>
+    Please provide the email of the department head who will be making cash decisions: <br/>
+    <input type="text" name="dept_head_email" />
+
+    <br/> <br/>
+    When will your department need its cash and/or MPoints in the morning and close at night? (Treasury closes at midnight.)
+    Departments will have ALL of their daily MPoints for each day dropped off in the morning, so if your department needs only MPoints then you can leave the "Department Closes" blank.
+    If your department needs cash, fill out both the Open and Closes values.
+    <br/>
+    <table class="padded" style="width:auto">
+    <thead>
+        <tr>
+            <th></th>
+            <th>Department Opens</th>
+            <th>Department Closes</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Thursday:</td>
+            <td class="centered"><input type="text" size="10" name="thu_start_time" /></td>
+            <td class="centered"><input type="text" size="10" name="thu_close_time" /></td>
+        </tr>
+        <tr>
+            <td>Friday:</td>
+            <td class="centered"><input type="text" size="10" name="fri_start_time" /></td>
+            <td class="centered"><input type="text" size="10" name="fri_clost_time" /></td>
+        </tr>
+        <tr>
+            <td>Saturday:</td>
+            <td class="centered"><input type="text" size="10" name="sat_start_time" /></td>
+            <td class="centered"><input type="text" size="10" name="sat_close_time" /></td>
+        </tr>
+        <tr>
+            <td>Sunday:</td>
+            <td class="centered"><input type="text" size="10" name="sun_start_time" /></td>
+            <td class="centered"><input type="text" size="10" name="sun_close_time" /></td>
+        </tr>
+    </tbody>
+    </table>
+
+    <br/>
+    <input type="checkbox" name="needs_cash" value="yes" onClick="showOrHideCash()"> My department needs cash
+    <div id="cash" style="display:none">
+        <a href="#" onClick="$('#prev-allotments').show() ; return false">Click here</a> to see a list of suggested allotments broken down by department.
+        <div id="prev-allotments" style="display:none">
+            Below is a list of suggested allotments based on what each department has needed in the past, adjusted for expected growth and changes in on-site fees.  Feel free to enter these numbers as-is or make changes if you think your department will have different needs than what is shown.
+            <table class="previous padded">
+            <thead>
+                <tr>
+                    <th></th>
+                    <th colspan="4">Total Cash</th>
+                    <th>Cash Boxes</th>
+                </tr>
+                <tr>
+                    <th></th>
+                    <th>$1</th>
+                    <th>$5</th>
+                    <th>$10</th>
+                    <th>$20</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Charity</td>
+                    <td>50</td>
+                    <td>20</td>
+                    <td>10</td>
+                    <td>10</td>
+                    <td class="centered">1</td>
+                </tr>
+                <tr>
+                    <td>Merchandise</td>
+                    <td>30</td>
+                    <td>20</td>
+                    <td>20</td>
+                    <td>15</td>
+                    <td class="centered">2</td>
+                </tr>
+                <tr>
+                    <td>Regdesk</td>
+                    <td>20</td>
+                    <td>20</td>
+                    <td>20</td>
+                    <td>5</td>
+                    <td class="centered">3</td>
+                </tr>
+                <tr>
+                    <td>Rock Island</td>
+                    <td>10</td>
+                    <td>4</td>
+                    <td>4</td>
+                    <td>6</td>
+                    <td class="centered">1</td>
+                </tr>
+                <tr>
+                    <td>Marketplace</td>
+                    <td>50</td>
+                    <td>50</td>
+                    <td>50</td>
+                    <td>50</td>
+                    <td class="centered">2</td>
+                </tr>
+            </tbody>
+            </table>
+        </div>
+
+        <br/> <br/>
+        Number of cash boxes your department needs at one time:
+        <input type="text" name="cash_boxes" size="3" />
+        
+        <br/> <br/>
+        For each cash box you recieve:
+        <table style="width:auto">
+        <tr>
+            <td>Number of $1 Bills</td>
+            <td><input type="text" name="1bills" size="3" /></td>
+        </tr>
+        <tr>
+            <td>Number of $5 Bills</td>
+            <td><input type="text" name="5bills" size="3" /></td>
+        </tr>
+        <tr>
+            <td>Number of $10 Bills</td>
+            <td><input type="text" name="10bills" size="3" /></td>
+        </tr>
+        <tr>
+            <td>Number of $20 Bills</td>
+            <td><input type="text" name="20bills" size="3" /></td>
+        </tr>
+        </table>
+    </div>
+
+    <br/> <br/>
+    Any other comments? <br/>
+    <textarea rows="5" cols="80" name="comments"></textarea>
+
+    <br/> <br/>
+    Notes:
+    <ul>
+        <li>
+            If we see a significant difference between cash requests between here and the suggested values,
+            then we will contact you to discuss the difference.
+        </li>
+        <li>
+            Answers here are not firm.  They will be a basis for final determination along with resource availability
+            and overall need.  For example, if there are shift conflicts, registration will probably take priority.
+        </li>
+    </ul>
+</div>
+<br/>
+<input type="submit" name="submitted" value="Submit Treasury Needs" />
+</form>
+
+{% endblock %}

--- a/magfest/templates/magfest_dept_checklist/allotments.txt
+++ b/magfest/templates/magfest_dept_checklist/allotments.txt
@@ -1,0 +1,34 @@
+My department needs cash and/or mpoints: {{ needs|yesno }}
+...but someone else is filling out this form: {{ defer|yesno }}
+
+Department head who will be making cash/MPoint decisions:
+{{ dept_head_name }}
+
+Email address of the department head who will be making cash/MPoint decisions:
+{{ dept_head_email }}
+
+CASH NEEDS:
+    My department needs cash: {{ needs_cash|yesno }}
+    Number of cash boxes: {{ cash_boxes }}
+    For each cash box:
+        Number of $1 Bills: {{ 1bills }}
+        Number of $5 Bills: {{ 5bills }}
+        Number of $10 Bills: {{ 10bills }}
+        Number of $20 Bills: {{ 20bills }}
+
+This department needs its cash/MPoints at this time in the morning:
+Thursday:
+    Opening: {{ thu_start_time }}
+    Closing: {{ thu_close_time }}
+Friday:
+    Opening: {{ fri_start_time }}
+    Closing: {{ fri_close_time }}
+Saturday:
+    Opening: {{ sat_start_time }}
+    Closing: {{ sat_close_time }}
+Sunday:
+    Opening: {{ sun_start_time }}
+    Closing: {{ sun_close_time }}
+
+{% if comments %}Other comments:
+{{ comments }}{% endif %}

--- a/magfest/templates/magfest_dept_checklist/tech_requirements.html
+++ b/magfest/templates/magfest_dept_checklist/tech_requirements.html
@@ -1,0 +1,16 @@
+{% extends "base-admin.html" %}
+{% block title %}Department Checklist - Tech Ops{% endblock %}
+{% block content %}
+
+<h2>Tech Requirements</h2>
+
+<h3><a href="{{ c.TECHOPS_DEPT_CHECKLIST_FORM_URL }}">{{ c.EVENT_NAME }} Tech Requirements Form</a></h3>
+
+<form method="post" action="tech_requirements">
+{% csrf_token %}
+Once you've filled out the form above, or if you don't need any equipment for your department, please click the button below.<br/>
+<br/>
+<input type="submit" name="submitted" value="I Have Filled out the Tech Requirements Form" />
+</form>
+
+{% endblock %}

--- a/magfest/templates/magfest_dept_checklist/treasury.html
+++ b/magfest/templates/magfest_dept_checklist/treasury.html
@@ -1,0 +1,49 @@
+{% extends "base-admin.html" %}
+{% block title %}Department Checklist - Tech Ops{% endblock %}
+{% block content %}
+
+<h2>MPoint Needs</h2>
+
+<h3><a href="{{ c.TREASURY_DEPT_CHECKLIST_FORM_URL }}">{{ c.EVENT_NAME_AND_YEAR }} MPoints Form</a></h3>
+
+<h2>Instructions</h2>
+<ol>
+    <li>If your department doesn't need any MPoints, just skip to the bottom and click the button to complete this step.</li>
+    <li>DO NOT change anything in row 12 or above.</li>
+    <li>For the contacts area, please do the following:
+    <ol type="a">
+        <li>Under Legal Name:</li>
+        <ol type="i">
+            <li>Enter the name of the people who can make decisions about MPoints in bold.</li>
+            <li>Enter the name of the people who can receive MPoints onsite in regular text.</li>
+        </ol>
+        <li>Under MAGName:</li>
+        <ol type="i">
+            <li>Enter the name the person is known by.  For example: Big Adam, Tronster, Hachi.</li>
+        </ol>
+        <li>Under email:</li>
+        <ol type="i">
+            <li>Enter the email address of the decision makers only.</li>
+        </ol>
+        <li>The list is pre-populated based on data from the last Prime and Classic, add and delete as necessary.</li>
+    </ol>
+    </li>
+    <li>The numbers contained in this spreadsheet include the amount of MPoints requested from the last MAGFest Prime, by denomination, for each department.  The last column in each department also represents the total amounts returned on Sunday.</li>
+    <li>All departments start with a “General” request.  If you want to enter separate MPoint requests for different divisions in your department, then copy and paste the General section to the columns next to it, change the title, and enter each division separately.
+    <ol type="a">
+        <li>As an example, see the Arcade and Consoles sections.</li>
+    </ol></li>
+    <li>Each section includes the requests, per day and denomination, from the last Prime.  For this Prime, determine the quantity of denominations you need for each day based on the “Thoughts” section above & what’s in the “Returned” column, and modify the numbers you want.  The “Total Requested” for the event should already calculate.  You can ignore the “Total Used” formula and the “Used” column.</li>
+    <li>Delete the numbers in the “Returned” column.</li>
+    <li>When you are done, please highlight all the rows in your section in dark green.</li>
+
+</ol>
+
+<form method="post" action="treasury">
+{% csrf_token %}
+Once you've filled out the form above OR done nothing if your department does not need MPoints, please click the button below.<br/>
+<br/>
+<input type="submit" name="submitted" value="I Have Filled out the MPoints Form" />
+</form>
+
+{% endblock %}


### PR DESCRIPTION
This repo is a new plugin called 'magfest', it's intended to be stuff that is used for all 3 of our events- magstock, magprime, and maglabs.

This code is unmodified from its iteration in the magprime plugin.  That code originally came from the magclassic plugin.  The checklist code has been deleted in both magprime and magclassic and now lives here.

I have also exposed the URLs via INI files for the techops and treasury external google/wufoo forms.
