### PR TITLE
Implement half-price child discounts for all MAG events

### DIFF
--- a/magfest/model_checks.py
+++ b/magfest/model_checks.py
@@ -1,0 +1,15 @@
+from . import *
+
+
+@prereg_validation.Attendee
+def group_leader_under_13(attendee):
+    if attendee.badge_type == c.PSEUDO_GROUP_BADGE and attendee.age_group_conf['val'] in [c.UNDER_6, c.UNDER_13]:
+        return "Children under 13 cannot be group leaders."
+
+
+@prereg_validation.Attendee
+def total_cost_over_paid(attendee):
+    if attendee.total_cost < attendee.amount_paid:
+        if attendee.orig_value_of('birthdate') < attendee.birthdate and attendee.age_group_conf['val'] in [c.UNDER_6, c.UNDER_13]:
+            return 'The date of birth you entered incurs a discount; please email {} to change your badge and receive a refund'.format(c.REGDESK_EMAIL)
+        return 'You have already paid ${}, you cannot reduce your extras below that.'.format(attendee.amount_paid)

--- a/magfest/models.py
+++ b/magfest/models.py
@@ -8,7 +8,7 @@ class Attendee:
         # We dynamically calculate the age discount to be half the current badge price.
         # If for some reason the default discount (if it exists) is greater than half off, we use that instead.
         if 'val' in self.age_group_conf and self.age_group_conf['val'] == c.UNDER_13:
-            half_off = math.ceil(c.BADGE_PRICE / 2) * 1
+            half_off = math.ceil(c.BADGE_PRICE / 2)
             if not self.age_group_conf['discount'] or self.age_group_conf['discount'] < half_off:
                 return -half_off
         return -self.age_group_conf['discount']

--- a/magfest/models.py
+++ b/magfest/models.py
@@ -3,8 +3,10 @@ from . import *
 
 @Session.model_mixin
 class Attendee:
-    @cost_property
-    def child_discount(self):
+    @property
+    def age_discount(self):
+        # We dynamically calculate the age discount to be half the current badge price
         if 'val' in self.age_group_conf and self.age_group_conf['val'] == c.UNDER_13:
             return math.ceil(c.BADGE_PRICE / 2) * -1
-        return 0
+        else:
+            return -self.age_group_conf['discount']

--- a/magfest/models.py
+++ b/magfest/models.py
@@ -5,8 +5,10 @@ from . import *
 class Attendee:
     @property
     def age_discount(self):
-        # We dynamically calculate the age discount to be half the current badge price
+        # We dynamically calculate the age discount to be half the current badge price.
+        # If for some reason the default discount (if it exists) is greater than half off, we use that instead.
         if 'val' in self.age_group_conf and self.age_group_conf['val'] == c.UNDER_13:
-            return math.ceil(c.BADGE_PRICE / 2) * -1
-        else:
-            return -self.age_group_conf['discount']
+            half_off = math.ceil(c.BADGE_PRICE / 2) * 1
+            if not self.age_group_conf['discount'] or self.age_group_conf['discount'] < half_off:
+                return -half_off
+        return -self.age_group_conf['discount']

--- a/magfest/models.py
+++ b/magfest/models.py
@@ -1,0 +1,10 @@
+from . import *
+
+
+@Session.model_mixin
+class Attendee:
+    @cost_property
+    def child_discount(self):
+        if 'val' in self.age_group_conf and self.age_group_conf['val'] == c.UNDER_13:
+            return math.ceil(c.BADGE_PRICE / 2) * -1
+        return 0

--- a/magfest/tests/models/test_attendee.py
+++ b/magfest/tests/models/test_attendee.py
@@ -1,5 +1,6 @@
 from uber import config
 from uber.tests import *
+from uber.tests.conftest import *
 
 
 class TestCosts:
@@ -8,14 +9,16 @@ class TestCosts:
         monkeypatch.setattr(c, 'get_oneday_price', Mock(return_value=10))
         monkeypatch.setattr(c, 'get_attendee_price', Mock(return_value=40))
 
-    def test_half_price_discount(self, monkeypatch):
+    def test_half_price_discount(self):
         # Age group discount not set: badge is half off
         assert 20 == Attendee(age_group=c.UNDER_13).badge_cost
 
+    def test_half_price_overrides_age_discount(self, monkeypatch):
         # Age group discount is less than half off: badge is half off
-        monkeypatch.setattr(Attendee, 'age_group_conf', {'discount': 5})
+        monkeypatch.setattr(Attendee, 'age_group_conf', {'val': c.UNDER_13, 'discount': 5})
         assert 20 == Attendee(age_group=c.UNDER_13).badge_cost
 
+    def test_age_discount_overrides_half_price(self, monkeypatch):
         # Age group discount is greater than half off: badge price based on age discount instead
         monkeypatch.setattr(Attendee, 'age_group_conf', {'discount': 30})
         assert 10 == Attendee(age_group=c.UNDER_13).badge_cost

--- a/magfest/tests/models/test_attendee.py
+++ b/magfest/tests/models/test_attendee.py
@@ -1,0 +1,21 @@
+from uber import config
+from uber.tests import *
+
+
+class TestCosts:
+    @pytest.fixture(autouse=True)
+    def mocked_prices(self, monkeypatch):
+        monkeypatch.setattr(c, 'get_oneday_price', Mock(return_value=10))
+        monkeypatch.setattr(c, 'get_attendee_price', Mock(return_value=40))
+
+    def test_half_price_discount(self, monkeypatch):
+        # Age group discount not set: badge is half off
+        assert 20 == Attendee(age_group=c.UNDER_13).badge_cost
+
+        # Age group discount is less than half off: badge is half off
+        monkeypatch.setattr(Attendee, 'age_group_conf', {'discount': 5})
+        assert 20 == Attendee(age_group=c.UNDER_13).badge_cost
+
+        # Age group discount is greater than half off: badge price based on age discount instead
+        monkeypatch.setattr(Attendee, 'age_group_conf', {'discount': 30})
+        assert 10 == Attendee(age_group=c.UNDER_13).badge_cost

--- a/magfest/tests/models/test_attendee.py
+++ b/magfest/tests/models/test_attendee.py
@@ -20,5 +20,5 @@ class TestCosts:
 
     def test_age_discount_overrides_half_price(self, monkeypatch):
         # Age group discount is greater than half off: badge price based on age discount instead
-        monkeypatch.setattr(Attendee, 'age_group_conf', {'discount': 30})
+        monkeypatch.setattr(Attendee, 'age_group_conf', {'val': c.UNDER_13, 'discount': 30})
         assert 10 == Attendee(age_group=c.UNDER_13).badge_cost


### PR DESCRIPTION
This code was in the magprime plugin, but both Stock and West leadership teams have requested this functionality so I'm copying it into our generic MAGFest plugin.