### PR TITLE
Remove base-admin.html

### DIFF
--- a/magfest/templates/magfest_dept_checklist/allotments.html
+++ b/magfest/templates/magfest_dept_checklist/allotments.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Department Checklist - Treasury{% endblock %}
 {% block content %}
 

--- a/magfest/templates/magfest_dept_checklist/tech_requirements.html
+++ b/magfest/templates/magfest_dept_checklist/tech_requirements.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Department Checklist - Tech Ops{% endblock %}
 {% block content %}
 

--- a/magfest/templates/magfest_dept_checklist/treasury.html
+++ b/magfest/templates/magfest_dept_checklist/treasury.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Department Checklist - Tech Ops{% endblock %}
 {% block content %}
 


### PR DESCRIPTION
Now that we have Jinja2 templating, we can use the variable admin_area to control what gets included in child templates, rather than inheriting from a different template. We're implementing that now.