### PR TITLE
Fix 500 error for price changes without an original DOB

### DIFF
--- a/magfest/model_checks.py
+++ b/magfest/model_checks.py
@@ -10,6 +10,6 @@ def group_leader_under_13(attendee):
 @prereg_validation.Attendee
 def total_cost_over_paid(attendee):
     if attendee.total_cost < attendee.amount_paid:
-        if attendee.orig_value_of('birthdate') < attendee.birthdate and attendee.age_group_conf['val'] in [c.UNDER_6, c.UNDER_13]:
+        if (not attendee.orig_value_of('birthdate') or attendee.orig_value_of('birthdate') < attendee.birthdate) and attendee.age_group_conf['val'] in [c.UNDER_6, c.UNDER_13]:
             return 'The date of birth you entered incurs a discount; please email {} to change your badge and receive a refund'.format(c.REGDESK_EMAIL)
         return 'You have already paid ${}, you cannot reduce your extras below that.'.format(attendee.amount_paid)


### PR DESCRIPTION
Got this traceback over the errors channel:
```
Traceback (most recent call last):
      File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/_cprequest.py", line 670, in respond
        response.body = self.handler()
      File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/lib/encoding.py", line 221, in __call__
        self.body = self.oldhandler(*args, **kwargs)
      File "/usr/local/uber/env/lib/python3.4/site-packages/cherrypy/_cpdispatch.py", line 60, in __call__
        return self.callable(*self.args, **self.kwargs)
      File "/usr/local/uber/plugins/uber/uber/decorators.py", line 252, in with_timing
        return func(*args, **kwargs)
      File "/usr/local/uber/plugins/uber/uber/decorators.py", line 267, in with_session
        retval = func(*args, session=session, **kwargs)
      File "/usr/local/uber/plugins/uber/uber/decorators.py", line 388, in with_restrictions
        return func(*args, **kwargs)
      File "/usr/local/uber/plugins/uber/uber/decorators.py", line 328, in with_rendering
        result = func(*args, **kwargs)
      File "/usr/local/uber/plugins/uber/uber/site_sections/preregistration.py", line 23, in wrapped
        return func(self, *args, **kwargs)
      File "/usr/local/uber/plugins/uber/uber/decorators.py", line 525, in check_id
        return func(*args, **params)
      File "/usr/local/uber/plugins/uber/uber/decorators.py", line 30, in with_check
        return func(*args, **kwargs)
      File "/usr/local/uber/plugins/uber/uber/site_sections/preregistration.py", line 584, in confirm
        message = check(attendee, prereg=True)
      File "/usr/local/uber/plugins/uber/uber/utils.py", line 128, in check
        message = validator(model)
      File "/usr/local/uber/plugins/magfest/magfest/model_checks.py", line 13, in total_cost_over_paid
        if attendee.orig_value_of('birthdate') < attendee.birthdate and attendee.age_group_conf['val'] in [c.UNDER_6, c.UNDER_13]:
    TypeError: unorderable types: NoneType() < datetime.date()
```

This should fix that.