### PR TITLE
Tie the band and panels plugins together for a 'guest' plugin

### DIFF
--- a/magfest/models.py
+++ b/magfest/models.py
@@ -12,3 +12,10 @@ class Attendee:
             if not self.age_group_conf['discount'] or self.age_group_conf['discount'] < half_off:
                 return -half_off
         return -self.age_group_conf['discount']
+
+@Session.model_mixin
+class Band:
+    @property
+    def panel_status(self):
+        return str(len(self.group.leader.panel_applications)) + " Panel Application(s)" \
+            if self.group.leader.panel_applications else self.status('panel')

--- a/magfest/models.py
+++ b/magfest/models.py
@@ -13,6 +13,7 @@ class Attendee:
                 return -half_off
         return -self.age_group_conf['discount']
 
+
 @Session.model_mixin
 class Band:
     @property

--- a/magfest/templates/band_admin/guest_info.html
+++ b/magfest/templates/band_admin/guest_info.html
@@ -1,0 +1,94 @@
+<style type="text/css">
+    .form-group { margin-bottom: 8px; }
+</style>
+
+<h2>Guest Info for <a href="../bands/index?id={{ band.id }}">{{ band.group.name }}</a></h2>
+
+<form class="form-horizontal" role="form" method="post" action="group_info">
+    {{ csrf_token() }}
+    <input type="hidden" name="id" value="{{ band.id }}" />
+
+    {% if band.group.leader.panel_applications %}
+      <div class="form-group">
+      <label class="col-sm-3 control-label">Panels</label>
+      <div class="col-sm-6">
+        <div class="form-control-static">
+          <a href="../panel_app_management/assigned_to?id={{ band.group.leader.id }}" target="_blank">
+          View the {{ band.group.leader.panel_applications|length }}
+            panel{{ band.group.leader.panel_applications|length|pluralize }} submitted by this guest.
+          </a>
+        </div>
+      </div>
+      </div>
+    {% endif %}
+
+    {{ macros.form_group(band.bio, 'desc', label='Bio', is_readonly=True) }}
+    {{ macros.form_group(band.bio, 'pic_url',
+        url_text="Click here to view the guest's uploaded picture",
+        url_is_relative=True,
+        label='Bio Pic',
+        is_readonly=True) }}
+
+    <div class="form-group">
+        <label class="col-sm-3 control-label">W9</label>
+        <div class="col-sm-6">
+          <div class="form-control-static">
+            {% if not band.payment %}
+            This guest isn't being paid and thus doesn't need a W9 tax form.
+            {% elif band.taxes.status %}
+            <a href="{{ band.taxes.w9_url }}">Click here to view the guest's uploaded W9 tax form</a>
+            {% else %}
+            This guest is supposed to be paid, but has not uploaded a W9 tax form yet.
+            {% endif %}
+          </div>
+        </div>
+    </div>
+
+    {{ macros.form_group(band.bio, 'website', type='url', is_readonly=True) }}
+    {{ macros.form_group(band.bio, 'facebook', is_readonly=True) }}
+    {{ macros.form_group(band.bio, 'twitter', is_readonly=True) }}
+    {{ macros.form_group(band.bio, 'other_social_media', is_readonly=True) }}
+    {{ macros.form_group(band.info, 'poc_phone', label='PoC Cellphone', is_readonly=True) }}
+
+    {% if band.info.bringing_vehicle %}
+      {{ macros.form_group(band.info, 'vehicle_info', is_readonly=True) }}
+    {% endif %}
+    {{ macros.form_group(band.info, 'arrival_time', is_readonly=True) }}
+
+    {{ macros.form_group(band.merch, 'selling_merch_label', label='Merchandise', is_readonly=True) }}
+    {{ macros.form_group(band.charity, 'donating_label', label='Charity', is_readonly=True) }}
+    {{ macros.form_group(band.charity, 'desc', label='Donation', is_readonly=True) }}
+
+    {{ macros.form_group(band, 'payment', type='number',
+        help="""The number of dollars we're paying the guest.  If you leave this
+        at zero, then no mention of payment will be made in their guest agreement,
+        otherwise the amount will be listed and the guest will be told they will
+        receive a check on-site after their performance.""") }}
+
+    {{ macros.form_group(band, 'vehicles', type='number',
+        help="The number of vehicles we're paying for parking (attached to the guest's room).") }}
+
+    {{ macros.form_group(band, 'num_hotel_rooms', type='number', label='Hotel Rooms',
+        help="How many hotel rooms are we offering the guest.") }}
+
+
+    <div class="form-group">
+        <label class="col-sm-3 control-label">Event</label>
+        <div class="col-sm-6">
+            <select name="event_id" class="form-control">
+                <option value="">Pick an Event</option>
+                {{ options(events,band.event_id) }}
+            </select>
+            <p class="help-block">
+                If not set, the guest agreement will say "date and time information coming soon"<br/>
+                If this is set, the guest agreement will reflect the start time of the event on the schedule.
+            </p>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="col-sm-6 col-sm-offset-3">
+            <button type="submit" class="btn btn-primary">Upload Guest Info</button>
+        </div>
+    </div>
+</form>

--- a/magfest/templates/checklist/guest_panel_deadline.html
+++ b/magfest/templates/checklist/guest_panel_deadline.html
@@ -1,0 +1,19 @@
+<tr>
+  <td width="25">{{ macros.checklist_image(band.group.leader.panel_applications) }}</td>
+  <td><b><a href="../panel_applications/guest?poc_id={{ band.group.leader.id }}">Submit a Panel Idea</a></b></td>
+  <td><i>Deadline:</i> {{ band.deadline_from_model('panel')|datetime_local }}</td>
+</tr>
+<tr>
+  <td colspan="3">
+    {% if not band.group.leader.panel_applications %}
+      Please use the above link to submit ideas for panels you want to run.
+    {% else %}
+      You have already submitted {{ band.group.leader.panel_applications|length }} panel
+      idea{{ band.group.leader.panel_applications|length|pluralize }}.
+      {% if c.APP_LIMIT %}
+        You may submit up to {{ c.APP_LIMIT }} panels for review.
+      {% endif %}
+    {% endif %}
+    <br/></br>
+  </td>
+</tr>


### PR DESCRIPTION
Adds overrides to the bands plugin which direct guests filling out their checklist to the panels plugin to apply for a panel. This way the bands and panels plugins are decoupled, but guests (and admins) can easily go from one to the other.